### PR TITLE
about:freedom / about:future cluster page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CCCV Chaos Computer Club Veranstaltungsgesellschaft mbH. Any projects hosted und
 ### Subdomain directory
 Use [pull requests](https://github.com/basisbit/rc3.github.io) to add your desired subdomain name to this list. Specify target IPv4/IPv6/... in the pull request description. First come, first serve. Subdomains which are dead for a couple of days may be replaced/reused.
 - [meet.rc3.io](https://meet.rc3.io) Forwards to senfcall.de, a donation based and GDPR compliant BigBlueButton service for many concurrent users (150 max per session).
-- [freedom.rc3.io](https://a-f.rc3.io) and [future.rc3.io](https://future.rc3.io) website for the about:freedom and about:future clusters, in lieu of the usual wiki page
+- [freedom.rc3.io](https://freedom.rc3.io) and [future.rc3.io](https://future.rc3.io) website for the about:freedom and about:future clusters, in lieu of the usual wiki page
 
 
 service provided by [basisbit](https://chaos.social/@basisbit)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ CCCV Chaos Computer Club Veranstaltungsgesellschaft mbH. Any projects hosted und
 ### Subdomain directory
 Use [pull requests](https://github.com/basisbit/rc3.github.io) to add your desired subdomain name to this list. Specify target IPv4/IPv6/... in the pull request description. First come, first serve. Subdomains which are dead for a couple of days may be replaced/reused.
 - [meet.rc3.io](https://meet.rc3.io) Forwards to senfcall.de, a donation based and GDPR compliant BigBlueButton service for many concurrent users (150 max per session).
+- [a-f.rc3.io](https://a-f.rc3.io) website for the about:freedom and about:future clusters, in lieu of the usual wiki page
 
 
 service provided by [basisbit](https://chaos.social/@basisbit)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CCCV Chaos Computer Club Veranstaltungsgesellschaft mbH. Any projects hosted und
 ### Subdomain directory
 Use [pull requests](https://github.com/basisbit/rc3.github.io) to add your desired subdomain name to this list. Specify target IPv4/IPv6/... in the pull request description. First come, first serve. Subdomains which are dead for a couple of days may be replaced/reused.
 - [meet.rc3.io](https://meet.rc3.io) Forwards to senfcall.de, a donation based and GDPR compliant BigBlueButton service for many concurrent users (150 max per session).
-- [a-f.rc3.io](https://a-f.rc3.io) website for the about:freedom and about:future clusters, in lieu of the usual wiki page
+- [freedom.rc3.io](https://a-f.rc3.io) and [future.rc3.io](https://future.rc3.io) website for the about:freedom and about:future clusters, in lieu of the usual wiki page
 
 
 service provided by [basisbit](https://chaos.social/@basisbit)


### PR DESCRIPTION
since apparently there won't be a congress wiki this year, we've moved our cluster page to its own website. The record should be a CNAME pointing to hainich.hacc.space (both subdomains — we only have one website, but two names …)

Thanks for running this repo, btw!